### PR TITLE
landlock: Add counted_by to access_masks in landlock_ruleset

### DIFF
--- a/security/landlock/ruleset.h
+++ b/security/landlock/ruleset.h
@@ -168,8 +168,7 @@ struct landlock_ruleset {
 			/**
 			 * @num_layers: Number of layers that are used in this
 			 * ruleset.  This enables to check that all the layers
-			 * allow an access request.  A value of 0 identifies a
-			 * non-merged ruleset (i.e. not a domain).
+			 * allow an access request.
 			 */
 			u32 num_layers;
 			/**
@@ -184,7 +183,8 @@ struct landlock_ruleset {
 			 * layers are set once and never changed for the
 			 * lifetime of the ruleset.
 			 */
-			struct access_masks access_masks[];
+			struct access_masks
+				access_masks[] __counted_by(num_layers);
 		};
 	};
 };


### PR DESCRIPTION
For a domain, this array stores the access masks for each layer (of which there are num_layers of them).  For an unmerged ruleset, we have one "layer", and one element in this array.  This annotation serves as useful documentation.

Signed-off-by: Tingmao Wang <m@maowtm.org> ---

This was initially spotted when working on the Landlock supervise RFC [1].

[1]: https://lore.kernel.org/all/6e8887f204c9fbe7470e61876bc597932a8f74d9.1741047969.git.m@maowtm.org/